### PR TITLE
Filter out non-GitHub-Action based checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # dist
 dist/package.json
+
+# local testing
+event.json

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ jobs:
 
 8. Create a PR for the main project.
 
+## Testing the GitHub action locally
+
+A GitHub action environment can be simulated via environment variables, and the event can be provided via a file.
+
+The following example assumes that the event is stored in the file `event.json`.
+If environment variable `INPUT_GITHUB_TOKEN` is set, the action will run with anonymous/read only access.
+
+```bash
+export GITHUB_EVENT_NAME=issue_comment
+export GITHUB_EVENT_PATH=event.json
+export INPUT_GITHUB_TOKEN=ghp_...
+export INPUT_DEBUG=true
+```
+
+After the environment variables are set, use the following command to execute the action:
+
+```bash
+node index.js
+```
+
 ## Reading about the GitHub APIs
 
 - [GitHub's REST API docs](https://docs.github.com/en/rest)

--- a/dist/index.js
+++ b/dist/index.js
@@ -27654,7 +27654,14 @@ async function run() {
         check.conclusion === "timed_out"
       ) {
         if (debug) {
-          console.log("Check:", check);
+          console.log("Check: ", check);
+        }
+
+        if (check.app.slug !== "github-actions") {
+          if (debug) {
+            console.log("Can only re-run github actions, ignoring this check.");
+          }
+          continue;
         }
 
         const job = unwrapResult(
@@ -27694,6 +27701,10 @@ async function run() {
 
 run().catch((err) => {
   console.error(err);
+  console.log(
+    "Payload that triggered this error: ",
+    JSON.stringify(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.payload)
+  );
   _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed("Unexpected error");
 });
 

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ run().catch((err) => {
   console.error(err);
   console.log(
     "Payload that triggered this error: ",
-    JSON.stringify(context.payload)
+    JSON.stringify(context.payload, null, 2)
   );
   core.setFailed("Unexpected error");
 });

--- a/index.js
+++ b/index.js
@@ -78,7 +78,14 @@ async function run() {
         check.conclusion === "timed_out"
       ) {
         if (debug) {
-          console.log("Check:", check);
+          console.log("Check: ", check);
+        }
+
+        if (check.app.slug !== "github-actions") {
+          if (debug) {
+            console.log("Can only re-run github actions, ignoring this check.");
+          }
+          continue;
         }
 
         const job = unwrapResult(
@@ -118,6 +125,10 @@ async function run() {
 
 run().catch((err) => {
   console.error(err);
+  console.log(
+    "Payload that triggered this error: ",
+    JSON.stringify(context.payload)
+  );
   core.setFailed("Unexpected error");
 });
 


### PR DESCRIPTION
Closes #6

The error can be reproduced with the following minimal `event.json` file as long as the PR 14318 in the Keycloak main repository is unchanged.

```
{
  "action": "created",
  "comment": {
    "author_association": "OWNER",
    "body": "/rerun"
  },
  "issue": {
    "number": 14318,
    "author_association": "OWNER",
    "pull_request": {},
    "state": "open"
  },
  "repository": {
    "owner": {
      "login": "keycloak"
    },
    "name": "keycloak"
  }
}
```

This also shows that this is fixed: When running with my personal access token it continues further and then complains that I don't have permission to re-run the job (this is expected). 